### PR TITLE
Switch test projects to Microsoft Testing Platform

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
     <PackageVersion Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="9.0.0" />
     <PackageVersion Include="Autofac" Version="9.1.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="EasyDoubles" Version="1.1.20" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
@@ -18,7 +17,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -40,6 +38,5 @@
     <PackageVersion Include="Verify.XunitV3" Version="31.19.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="TIKSN-Framework" Version="5.7.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestMajor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/API.FunctionalTests/API.FunctionalTests.csproj
+++ b/tests/API.FunctionalTests/API.FunctionalTests.csproj
@@ -1,24 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyDoubles" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="TIKSN-Framework" />
     <PackageReference Include="UUIDNext" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/API.FunctionalTests/testconfig.json
+++ b/tests/API.FunctionalTests/testconfig.json
@@ -1,0 +1,5 @@
+{
+  "xUnit": {
+    "parallelizeTestCollections": false
+  }
+}

--- a/tests/API.FunctionalTests/xunit.runner.json
+++ b/tests/API.FunctionalTests/xunit.runner.json
@@ -1,5 +1,0 @@
-﻿{
-  "shadowCopy": false,
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}

--- a/tests/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/tests/API.IntegrationTests/API.IntegrationTests.csproj
@@ -1,33 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EasyDoubles" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="TIKSN-Framework" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\API.Infrastructure\API.Infrastructure.csproj" />
     <ProjectReference Include="..\API.UnitTests\API.UnitTests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" />

--- a/tests/API.UnitTests/API.UnitTests.csproj
+++ b/tests/API.UnitTests/API.UnitTests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,27 +10,13 @@
   <ItemGroup>
     <PackageReference Include="EasyDoubles" />
     <PackageReference Include="IdGen.DependencyInjection" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="TIKSN-Framework" />
     <PackageReference Include="Verify.XunitV3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="xunit.v3" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\API.Core\API.Core.csproj" />

--- a/tests/API.UnitTests/testconfig.json
+++ b/tests/API.UnitTests/testconfig.json
@@ -1,0 +1,5 @@
+{
+  "xUnit": {
+    "parallelizeTestCollections": false
+  }
+}

--- a/tests/API.UnitTests/xunit.runner.json
+++ b/tests/API.UnitTests/xunit.runner.json
@@ -1,5 +1,0 @@
-﻿{
-  "shadowCopy": false,
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
## Summary
- Migrates the three xUnit v3 test projects to native .NET 10 Microsoft Testing Platform mode.
- Removes VSTest-only test runner packages and the unused Coverlet collector references.
- Replaces `xunit.runner.json` with MTP-compatible `testconfig.json` where xUnit configuration is still needed.

## Testing
- `dotnet restore API.slnx`
- `dotnet build API.slnx`
- `dotnet test` for unit, functional, and integration test projects
- `./test.ps1 -Fast`