### PR TITLE
Replace the zero-test MTP workaround with a MongoDB integration test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.12.0" />
     <PackageVersion Include="UnitGenerator" Version="2.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The application provides a health check endpoint to monitor its status.
 ### Prerequisites
 
 *   .NET 10 SDK
+*   Docker, for Testcontainers-backed integration tests
 *   An identity provider like FusionAuth running.
 
 ### Instructions
@@ -77,3 +78,11 @@ The application provides a health check endpoint to monitor its status.
     ```
 
 3.  The API will be available at `http://localhost:5000` (or as configured in `launchSettings.json`).
+
+### Testing
+
+Integration tests use Testcontainers and require a running Docker daemon. Run the integration suite with:
+
+```sh
+dotnet test tests/API.IntegrationTests/API.IntegrationTests.csproj
+```

--- a/tests/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/tests/API.IntegrationTests/API.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -11,10 +10,12 @@
     <PackageReference Include="EasyDoubles" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="TIKSN-Framework" />
+    <PackageReference Include="Testcontainers.MongoDb" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\API.Web\API.Web.csproj" />
     <ProjectReference Include="..\..\src\API.Infrastructure\API.Infrastructure.csproj" />
     <ProjectReference Include="..\API.UnitTests\API.UnitTests.csproj" />
   </ItemGroup>
@@ -22,6 +23,7 @@
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Verify.XunitV3" />
+    <Using Include="Xunit" />
     <Using Include="LanguageExt" />
     <Using Include="LanguageExt.Common" />
     <Using Include="LanguageExt.Effects" />

--- a/tests/API.IntegrationTests/MongoDbContainerFixture.cs
+++ b/tests/API.IntegrationTests/MongoDbContainerFixture.cs
@@ -1,4 +1,4 @@
-using Testcontainers.MongoDb;
+﻿using Testcontainers.MongoDb;
 
 namespace Fossa.API.IntegrationTests;
 

--- a/tests/API.IntegrationTests/MongoDbContainerFixture.cs
+++ b/tests/API.IntegrationTests/MongoDbContainerFixture.cs
@@ -1,0 +1,21 @@
+using Testcontainers.MongoDb;
+
+namespace Fossa.API.IntegrationTests;
+
+public sealed class MongoDbContainerFixture : IAsyncLifetime
+{
+  private readonly MongoDbContainer _container = new MongoDbBuilder("mongo:8.0")
+    .Build();
+
+  public string ConnectionString => _container.GetConnectionString();
+
+  public async ValueTask InitializeAsync()
+  {
+    await _container.StartAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await _container.DisposeAsync().ConfigureAwait(false);
+  }
+}

--- a/tests/API.IntegrationTests/MongoDbHealthCheckTests.cs
+++ b/tests/API.IntegrationTests/MongoDbHealthCheckTests.cs
@@ -1,4 +1,4 @@
-using Fossa.API.Web.HealthChecks;
+﻿using Fossa.API.Web.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Shouldly;
 

--- a/tests/API.IntegrationTests/MongoDbHealthCheckTests.cs
+++ b/tests/API.IntegrationTests/MongoDbHealthCheckTests.cs
@@ -1,0 +1,27 @@
+using Fossa.API.Web.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+
+namespace Fossa.API.IntegrationTests;
+
+public sealed class MongoDbHealthCheckTests(MongoDbContainerFixture mongoDb) : IClassFixture<MongoDbContainerFixture>
+{
+  [Fact]
+  public async Task CheckHealthAsync_WithRunningMongoDbContainer_ShouldReportHealthy()
+  {
+    var healthCheck = new MongoDbHealthCheck(mongoDb.ConnectionString);
+    var context = new HealthCheckContext
+    {
+      Registration = new HealthCheckRegistration(
+        "mongodb",
+        _ => healthCheck,
+        HealthStatus.Unhealthy,
+        tags: null),
+    };
+
+    var result = await healthCheck.CheckHealthAsync(context, TestContext.Current.CancellationToken);
+
+    result.Status.ShouldBe(HealthStatus.Healthy);
+    result.Exception.ShouldBeNull();
+  }
+}


### PR DESCRIPTION
## Summary
- Remove the Microsoft Testing Platform `--ignore-exit-code 8` workaround from `API.IntegrationTests`
- Add `Testcontainers.MongoDb` and a shared MongoDB fixture for the integration test project
- Add a real xUnit integration test that verifies the MongoDB health check succeeds against a running container
- Document the Docker/Testcontainers prerequisite in `README.md`

## Testing
- `dotnet test tests/API.IntegrationTests/API.IntegrationTests.csproj` passed with 1 discovered integration test
- `./test.ps1 -Fast` passed across unit, functional, and integration test suites